### PR TITLE
Feature/delete main suspense

### DIFF
--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,7 +1,6 @@
 import React, { Suspense } from 'react';
 import { redirect } from 'next/navigation';
 
-import { Loading } from '../_components/Loading';
 import { getSession } from '../lib/commonFunction';
 import { AIAdvice } from './_components/_AIAdvice/AIAdvice';
 import { BalanceContainer } from './_components/_BalanceDisplayAndAdd/BalanceContainer';
@@ -17,9 +16,7 @@ const page = async () => {
 
   return (
     <div>
-      <Suspense fallback={<Loading />}>
-        <BalanceContainer />
-      </Suspense>
+      <BalanceContainer />
       <AIAdvice />
       <Suspense fallback={<SkeletonProgressItem />}>
         <BalanceProgress />


### PR DESCRIPTION
## Issue
#92 

## 概要
メインページの残高取得にはあまり時間がかからないため、LayoutShiftのデメリットを重視し、Suspenseを破棄した。

## 対応内容
・mainページのBalanceContainerコンポーネントを囲っていたSuspenseを破棄。

## 動作確認内容
既存のテストで確認

## 影響範囲
なし

## 未対応内容・課題
なし

## レビュー観点
なし

## 補足
なし