### PR TITLE
Feature/fix fetch data

### DIFF
--- a/src/app/logManagement/logTable/[page]/page.tsx
+++ b/src/app/logManagement/logTable/[page]/page.tsx
@@ -1,16 +1,16 @@
 import React, { Suspense } from 'react';
 import { redirect } from 'next/navigation';
 
-import { getSession } from '@/app/lib/commonFunction';
+import { getSessionAndUserId } from '@/app/lib/commonFunction';
 import { Pagination } from '../_components/Pagination';
 import { SkeletonTable } from '../_components/SkeletonTable';
 import { Table } from '../_components/Table';
 
 const page = async ({ params }: { params: Promise<{ page: string }> }) => {
-  // 認証チェック
-  const session = await getSession();
-  if (!session) {
-    redirect('/');
+  // 認証チェック＋ユーザーIDのpreload
+  const userId = await getSessionAndUserId();
+  if (!userId) {
+    redirect('/signIn');
   }
   // パラメータからページ番号を取得
   const { page } = await params;

--- a/src/app/main/_components/_BalanceProgress/BalanceProgress.tsx
+++ b/src/app/main/_components/_BalanceProgress/BalanceProgress.tsx
@@ -1,5 +1,5 @@
 import {
-  getFavoriteWantedItemListWithoutPurchasedAnd,
+  getFavoriteWantedItemListWithoutPurchased,
   getSessionAndUserId
 } from '@/app/lib/commonFunction';
 import { BalanceProgressItem } from './BalanceProgressItem';
@@ -10,7 +10,7 @@ export const BalanceProgress = async () => {
     const userId = await getSessionAndUserId();
     // 欲しい物リスト取得（未購入かつお気に入り）
     const wantedItemList =
-      await getFavoriteWantedItemListWithoutPurchasedAnd(userId);
+      await getFavoriteWantedItemListWithoutPurchased(userId);
 
     return (
       <div className="flex justify-center p-4 sm:p-6">

--- a/src/app/main/_components/_purchaseWantedItem/PurchaseWantedItem.tsx
+++ b/src/app/main/_components/_purchaseWantedItem/PurchaseWantedItem.tsx
@@ -20,7 +20,7 @@ export const PurchaseWantedItem = async ({
   // パラメーター取得
   const { id } = params;
 
-  // 削除対象のログを取得
+  // 削除対象のアイテムを取得
   let item = null;
   try {
     item = await prisma.wantedItem.findUnique({

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,18 +1,20 @@
 import React, { Suspense } from 'react';
 import { redirect } from 'next/navigation';
 
-import { getSession } from '../lib/commonFunction';
+import { getSessionAndUserId, preloadForMainPage } from '../lib/commonFunction';
 import { AIAdvice } from './_components/_AIAdvice/AIAdvice';
 import { BalanceContainer } from './_components/_BalanceDisplayAndAdd/BalanceContainer';
 import { BalanceProgress } from './_components/_BalanceProgress/BalanceProgress';
 import { SkeletonProgressItem } from './_components/_BalanceProgress/SkeletonProgressItem';
 
 const page = async () => {
-  // 認証チェック
-  const session = await getSession();
-  if (!session) {
+  // 認証チェック＋ユーザーIDのpreload
+  const userId = await getSessionAndUserId();
+  if (!userId) {
     redirect('/signIn');
   }
+  // preload
+  await preloadForMainPage(userId);
 
   return (
     <div>

--- a/src/app/wantedItemManagement/_components/_PurchasedItemList/List.tsx
+++ b/src/app/wantedItemManagement/_components/_PurchasedItemList/List.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {
-  getPurchaseItemList,
+  getPurchasedItemList,
   getSessionAndUserId
 } from '@/app/lib/commonFunction';
 import { Row } from './Row';
@@ -11,7 +11,7 @@ export const List = async () => {
     // UserIDを取得
     const userId = await getSessionAndUserId();
     // 欲しい物リストを取得
-    const purchaseItemList = await getPurchaseItemList(userId);
+    const purchaseItemList = await getPurchasedItemList(userId);
 
     return (
       <div>

--- a/src/app/wantedItemManagement/page.tsx
+++ b/src/app/wantedItemManagement/page.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
 import { redirect } from 'next/navigation';
 
-import { getSession } from '../lib/commonFunction';
+import {
+  getSessionAndUserId,
+  preloadForWantedItemManagementPage
+} from '../lib/commonFunction';
 import { AddWantedItem } from './_components/_AddWantedItem/AddWantedItem';
 import { PurchasedItemList } from './_components/_PurchasedItemList/PurchasedItemList';
 import { WantedItemList } from './_components/_WantedItemList/WantedItemList';
 
 const page = async () => {
-  // 認証チェック
-  const session = await getSession();
-  if (!session) {
+  // 認証チェック＋ユーザーIDのpreload
+  const userId = await getSessionAndUserId();
+  if (!userId) {
     redirect('/signIn');
   }
+  // preload
+  await preloadForWantedItemManagementPage(userId);
+
   return (
     <div>
       <AddWantedItem />


### PR DESCRIPTION
## Issue
#95 

## 概要
並行フェッチの見直し

## 対応内容
・並行フェッチを可能な限り増やすためにpreloadパターンを導入
・メインページ、ほしい物リストページにて、preloadパターンを導入。また、commonFunctionsにpreload用の関数をページごとに定義。

## 動作確認内容
既存のテストで確認

## 影響範囲
なし

## 未対応内容・課題
なし

## レビュー観点
preloadが正しく実装されているか

## 補足
なし