### PR TITLE
Feature/fix header title bug

### DIFF
--- a/src/app/_components/_Header/Title.test.tsx
+++ b/src/app/_components/_Header/Title.test.tsx
@@ -11,7 +11,7 @@ describe('Title', () => {
 
     // リンクが存在し、href属性が正しいことを確認
     const linkElement = screen.getByRole('link', {
-      name: 'メインページに移動'
+      name: 'ルートに移動'
     });
     expect(linkElement).toBeInTheDocument();
     expect(linkElement).toHaveAttribute('href', '/');

--- a/src/app/_components/_Header/Title.test.tsx
+++ b/src/app/_components/_Header/Title.test.tsx
@@ -14,7 +14,7 @@ describe('Title', () => {
       name: 'メインページに移動'
     });
     expect(linkElement).toBeInTheDocument();
-    expect(linkElement).toHaveAttribute('href', '/main');
+    expect(linkElement).toHaveAttribute('href', '/');
 
     // テキスト「ちりつも」が正しく表示されていることを確認
     const titleText = screen.getByRole('heading', {

--- a/src/app/_components/_Header/Title.tsx
+++ b/src/app/_components/_Header/Title.tsx
@@ -6,9 +6,9 @@ export const Title = () => {
   return (
     <header>
       <Link
-        href="/main"
+        href="/"
         className="flex items-center gap-2"
-        aria-label="メインページに移動"
+        aria-label="ルートに移動"
       >
         <TbMountain size={35} data-testid="icon" />
         <h1 className="pt-[3px] text-3xl font-bold text-gray-800">ちりつも</h1>


### PR DESCRIPTION
## Issue
#98 

## 概要
ヘッダーのタイトル遷移先バグ修正

## 対応内容
ヘッダーのタイトルの遷移先が"/"でなく"/main"になっているバグを解消する

## 動作確認内容
既存のユニットテストで確認

## 影響範囲
なし

## 未対応内容・課題
なし

## レビュー観点
未ログイン状態でヘッダーのタイトルを押下した際にエラーが発生しないこと

## 補足
なし